### PR TITLE
test: make Candidate CLI checks Windows-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         # contracts. Windows is covered by the desktop/native suite below and
         # by the checkout-free installed NSIS smoke in unsigned-packages.yml.
         if: runner.os != 'Windows'
+      - run: npm run test:cli
       # npm may restore the Electron package without its platform binary from
       # cache. The pinned install script is idempotent and closes that gap.
       - run: node desktop/ambient-orb/node_modules/electron/install.js

--- a/cli/src/runtime.mjs
+++ b/cli/src/runtime.mjs
@@ -403,7 +403,6 @@ export function launchDesktop(executable, {
         child.unref()
         resolveLaunch()
       }, launchGraceMs)
-      launchTimer.unref?.()
     })
   })
 }

--- a/cli/test/target.test.mjs
+++ b/cli/test/target.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import {readFile} from 'node:fs/promises'
+import {join} from 'node:path'
 import {test} from 'node:test'
 
 import {
@@ -23,11 +24,11 @@ test('release and settings paths use the documented local roots', () => {
   const target = resolveTarget('linux', 'x64')
   assert.equal(
     releaseRoot({home: '/tmp/home', target}),
-    '/tmp/home/.nova-audio-agent/cli/releases/0.1.0/linux-x64',
+    join('/tmp/home', '.nova-audio-agent', 'cli', 'releases', '0.1.0', 'linux-x64'),
   )
   assert.equal(
     desktopSettingsPath({platform: 'linux', home: '/tmp/home', environment: {}}),
-    '/tmp/home/.config/Nova Audio Agent Ambient Orb/ambient-orb-settings.json',
+    join('/tmp/home', '.config', 'Nova Audio Agent Ambient Orb', 'ambient-orb-settings.json'),
   )
   assert.equal(releaseBaseUrl(), 'https://github.com/deepnovacore/NovaAudioAgent/releases/download/v0.1.0')
 })

--- a/desktop/ambient-orb/test/builder-config.test.mjs
+++ b/desktop/ambient-orb/test/builder-config.test.mjs
@@ -423,6 +423,8 @@ test('ordinary CI uploads package artifacts only for version tags', async () => 
   assert.deepEqual(workflow.jobs.electron.strategy.matrix.os, [
     'macos-latest', 'ubuntu-latest', 'windows-latest',
   ])
+  const cliTest = workflow.jobs.electron.steps.find(step => step.run === 'npm run test:cli')
+  assert.deepEqual(cliTest, {run: 'npm run test:cli'})
   assert.equal(
     workflow.jobs.electron.steps.some(step => step.uses === 'actions/upload-artifact@v4'),
     false,


### PR DESCRIPTION
Fixes the two Windows-only failures found by Candidate run 33475290148: keep the startup grace timer referenced until launch settles, and build path expectations with node:path.join.\n\nValidation: npm run test:cli (18/18).