### PR TITLE
Fix packaged POSIX project host loading

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 jobs:
   platform-candidate:
@@ -65,6 +63,8 @@ jobs:
       - name: Build unsigned candidate bytes
         run: npm run ${{ matrix.package_script }} --workspace @nova-audio-agent/ambient-orb
       - name: Inspect exact unsigned application and installer bytes
+        env:
+          NOVA_RELEASE_INSPECTION_DIAGNOSTICS: "1"
         run: npm run inspect:release-package --workspace @nova-audio-agent/ambient-orb
       - name: Provision pinned target-native Codex
         run: npm install --prefix desktop/ambient-orb/build/release-codex --install-strategy=nested --package-lock=false --ignore-scripts --no-save --omit=dev @openai/codex@0.147.0
@@ -76,10 +76,6 @@ jobs:
         run: npm run collect:release-artifacts --workspace @nova-audio-agent/ambient-orb -- --target-id ${{ matrix.target_id }}
       - name: Prepare checkout-free installed smoke kit
         run: npm run prepare:release-smoke-kit --workspace @nova-audio-agent/ambient-orb
-      - name: Attest exact final candidate files
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: desktop/ambient-orb/build/release-artifacts/*
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
@@ -94,7 +90,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      attestations: read
     strategy:
       fail-fast: false
       matrix:
@@ -148,15 +143,12 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: candidate
-      - name: Rehash, attest, install, authenticate, exercise, quit, and remove candidate
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Rehash, install, authenticate, exercise, quit, and remove candidate
         run: >-
-          ${{ matrix.command }} candidate/release-smoke-kit/scripts/installed-candidate-smoke.mjs
+          ${{ matrix.command }} candidate/release-smoke-kit/scripts/run-unsigned-installed-smoke.mjs
           --target ${{ matrix.target }}
           --artifact candidate/release-artifacts/${{ matrix.filename }}
           --sha256-file candidate/release-digests/${{ matrix.filename }}.sha256
-          --commit ${{ github.sha }}
           --camera-file candidate/release-smoke-kit/cat-sofa-guard.mp4
 
   pending-candidate-ledger:
@@ -172,7 +164,7 @@ jobs:
         with:
           pattern: candidate-*
           path: downloaded
-      - name: Assemble only the complete attested candidate matrix
+      - name: Assemble only the complete digest-bound candidate matrix
         run: node desktop/ambient-orb/scripts/assemble-release-artifact-root.mjs --input downloaded --output candidate-artifacts
       - name: Generate the honest pending external-evidence ledger
         env:
@@ -188,12 +180,6 @@ jobs:
           npm run generate:release-candidate-report --workspace @nova-audio-agent/ambient-orb --
           --ledger candidate-ledger-v1.json
           --output candidate-report.md
-      - name: Attest the pending ledger and report bytes
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: |
-            candidate-ledger-v1.json
-            candidate-report.md
       - uses: actions/upload-artifact@v4
         with:
           name: pending-candidate-ledger

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -52,7 +52,7 @@ jobs:
       - run: npm ci
         if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run check
-        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
+        if: inputs.candidate_scope == 'full'
       - run: npm run test:runtime
         # The complete runtime suite asserts POSIX uid/mode and descriptor-lock
         # contracts. Windows is covered by the desktop/native suite below and
@@ -63,9 +63,9 @@ jobs:
       - run: node desktop/ambient-orb/node_modules/electron/install.js
         if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run test:desktop
-        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
+        if: inputs.candidate_scope == 'full'
       - run: npm run test:cli
-        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
+        if: inputs.candidate_scope == 'full'
       - name: Build unsigned candidate bytes
         if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         run: npm run ${{ matrix.package_script }} --workspace @nova-audio-agent/ambient-orb

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -24,21 +24,11 @@ jobs:
             target_id: darwin-arm64
             package_script: package:mac:candidate
             artifact_name: candidate-darwin-arm64
-          - os: macos-15-intel
-            platform: darwin
-            target_id: darwin-x64
-            package_script: package:mac:candidate
-            artifact_name: candidate-darwin-x64
           - os: windows-latest
             platform: win32
             target_id: win32-x64
             package_script: package:win
             artifact_name: candidate-win32-x64
-          - os: ubuntu-latest
-            platform: linux
-            target_id: linux-x64-gnu
-            package_script: package:linux
-            artifact_name: candidate-linux-x64-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -104,16 +94,6 @@ jobs:
             artifact_name: candidate-darwin-arm64
             filename: nova-audio-agent-0.1.0-macos-arm64.dmg
             command: node
-          - os: macos-15-intel
-            target: darwin-x64:app
-            artifact_name: candidate-darwin-x64
-            filename: nova-audio-agent-0.1.0-macos-x64-app.zip
-            command: node
-          - os: macos-15-intel
-            target: darwin-x64:dmg
-            artifact_name: candidate-darwin-x64
-            filename: nova-audio-agent-0.1.0-macos-x64.dmg
-            command: node
           - os: windows-latest
             target: win32-x64:portable
             artifact_name: candidate-win32-x64
@@ -124,16 +104,6 @@ jobs:
             artifact_name: candidate-win32-x64
             filename: nova-audio-agent-0.1.0-windows-x64.exe
             command: node
-          - os: ubuntu-latest
-            target: linux-x64-gnu:appimage
-            artifact_name: candidate-linux-x64-gnu
-            filename: nova-audio-agent-0.1.0-linux-x64.AppImage
-            command: xvfb-run -a node
-          - os: ubuntu-latest
-            target: linux-x64-gnu:deb
-            artifact_name: candidate-linux-x64-gnu
-            filename: nova-audio-agent-0.1.0-linux-x64.deb
-            command: xvfb-run -a node
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v4

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -8,6 +8,14 @@ on:
         required: true
         default: 0.1.0
         type: string
+      candidate_scope:
+        description: Full release evidence or a Windows-only repair run
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - windows
 
 permissions:
   contents: read
@@ -32,41 +40,56 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - uses: actions/setup-node@v4
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm install --global npm@11.6.0
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm ci
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run check
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run test:runtime
         # The complete runtime suite asserts POSIX uid/mode and descriptor-lock
         # contracts. Windows is covered by the desktop/native suite below and
         # by the checkout-free installed smoke for both Windows artifacts.
-        if: runner.os != 'Windows'
+        if: (inputs.candidate_scope == 'full' || matrix.platform == 'win32') && runner.os != 'Windows'
       # npm may restore the Electron package without its platform binary from
       # cache. The pinned install script is idempotent and closes that gap.
       - run: node desktop/ambient-orb/node_modules/electron/install.js
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run test:desktop
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - run: npm run test:cli
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
       - name: Build unsigned candidate bytes
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         run: npm run ${{ matrix.package_script }} --workspace @nova-audio-agent/ambient-orb
       - name: Inspect exact unsigned application and installer bytes
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         env:
           NOVA_RELEASE_INSPECTION_DIAGNOSTICS: "1"
         run: npm run inspect:release-package --workspace @nova-audio-agent/ambient-orb
       - name: Provision pinned target-native Codex
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         run: npm install --prefix desktop/ambient-orb/build/release-codex --install-strategy=nested --package-lock=false --ignore-scripts --no-save --omit=dev @openai/codex@0.147.0
       - name: Exercise packaged project authority, sandbox probe, and app-server lifecycle
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         env:
           NOVA_AUDIO_AGENT_CODEX_API_KEY: offline-platform-contract-only
         run: npm run smoke:packaged-codex:ci --workspace @nova-audio-agent/ambient-orb
       - name: Normalize closed release artifact names and final digests
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         run: npm run collect:release-artifacts --workspace @nova-audio-agent/ambient-orb -- --target-id ${{ matrix.target_id }}
       - name: Prepare checkout-free installed smoke kit
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         run: npm run prepare:release-smoke-kit --workspace @nova-audio-agent/ambient-orb
       - uses: actions/upload-artifact@v4
+        if: inputs.candidate_scope == 'full' || matrix.platform == 'win32'
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -107,13 +130,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-node@v4
+        if: inputs.candidate_scope == 'full' || startsWith(matrix.target, 'win32-x64:')
         with:
           node-version: "22"
       - uses: actions/download-artifact@v4
+        if: inputs.candidate_scope == 'full' || startsWith(matrix.target, 'win32-x64:')
         with:
           name: ${{ matrix.artifact_name }}
           path: candidate
       - name: Rehash, install, authenticate, exercise, quit, and remove candidate
+        if: inputs.candidate_scope == 'full' || startsWith(matrix.target, 'win32-x64:')
         run: >-
           ${{ matrix.command }} candidate/release-smoke-kit/scripts/run-unsigned-installed-smoke.mjs
           --target ${{ matrix.target }}
@@ -123,6 +149,7 @@ jobs:
 
   pending-candidate-ledger:
     needs: installed-candidate-smoke
+    if: inputs.candidate_scope == 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -119,7 +119,7 @@ jobs:
           gh release edit v0.1.0 \
             --target "$EXPECTED_COMMIT" \
             --title "Nova Audio Agent v0.1.0" \
-            --notes "Replacement for the original Windows-only v0.1.0. This release now includes macOS arm64/x64, Windows x64, and Linux x64 portable applications plus installers. These builds are unsigned; macOS Gatekeeper and Windows SmartScreen may display security warnings."
+            --notes "Replacement for the original Windows-only v0.1.0. This release now includes macOS arm64 and Windows x64 portable applications plus installers. These builds are unsigned; macOS Gatekeeper and Windows SmartScreen may display security warnings."
           gh release upload v0.1.0 release-artifacts/* --clobber
       - name: Launch the packed npm CLI against the replacement release before publish
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,13 @@ integrations demonstrate the same missing primitive.
 Follow [Executor onboarding](docs/archs/10-executor-onboarding.md):
 
 1. Write the manifest and parameter schemas.
-2. Define trust, deadline, side-effect, and verification behavior for every operation.
+2. Define `readonly`, `confirm`, `deadline_budget`, `verifies`, `sensitive_params`, and
+   `sync_result` for every operation. Classify trust on the handoff, not on the op spec.
 3. Implement a transport-independent adapter with deterministic doubles.
-4. Add it to assembly's explicit registry and configuration literal.
-5. Add adapter-consistency, invalid-input, timeout, cancellation, and sanitization tests.
+4. Wire it in `buildAssembly`. Always-on adapters (search, cam, watch, guard) are constructed
+   there unconditionally. Configurable adapters also join the `fast_sim` / `slow_sim` / `codex`
+   configuration literal.
+5. Add invalid-input, timeout, cancellation, sanitization, and registry-adapter contract tests.
 6. Add a live smoke only after deterministic lifecycle coverage passes.
 7. Document credentials and least-privilege setup in [Getting started](docs/getting-started.md).
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@
 
 > **An always-on voice agent with restrained proactivity and the capability of workspace management.**
 
-https://github.com/user-attachments/assets/0ca76117-f6d2-46fc-80c3-8a8cee603fc6
+https://github.com/user-attachments/assets/061697f3-fff6-47d6-924b-8a29eef4ab45
 
 ## 1. Highlights
 
 Nova Audio Agent is a **harness for an always-on, general-purpose voice agent**: Nova (小诺)
-keeps the conversation responsive while doing long-running tasks in the background, reporting
+keeps responsive while doing long-running tasks in the background, reporting
 **proper** progress at **proper** time.
 
 A concurrent work [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) answers
-*how to keep an agent talking while it works*, while we ask the mirror question — **when is talking
+*how to keep an agent talking while it works*, while we ask a step further — **when is talking
 worth it at all** (see the [design post](docs/blog/2026-08-proactive-voice-agent-design-space.md) for more details).
 
 
-- **Restrained proactivity:** Not all words are created equal, for example, *trivial events from codex not worth saying, milestones should be reported, guardians should take over*. The agent stays silent for plain coding progress, reports progress for milestones. Alerts have higher speaking rights, where the agent interrupts itself or even  user.
+- **Restrained proactivity:** Not all words are created equal, for example, *trivial events from codex not worth saying, milestones should be reported, guardians should take over*. The agent stays silent for plain coding progress and reports progress for milestones. Alerts have higher speaking rights, where the agent interrupts itself or even  user.
 - **Workspace management.** No need to manage your workspaces manually as in codex, our agent does that for you. Workspaces/sessions can be created/switched via pure voice control(proposed and confirmed).
 - **Intent clarification and save your tokens.** For under-specified requirements, the agent will first clarify your intent before proceeding to dispatch, which *saves about 31% tokens* in our internal tests.
 - **Real-time steering**. Our codex executor is built upon native codex app-server instead of ACP, which allows real-time steering.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 > **Agent 常驻在线、主动但是有分寸、通过语音帮你管理所有工作区 -- 干活不停，言语有度**
 
-https://github.com/user-attachments/assets/0ca76117-f6d2-46fc-80c3-8a8cee603fc6
+https://github.com/user-attachments/assets/061697f3-fff6-47d6-924b-8a29eef4ab45
 
 ## 1. 核心特性
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,6 +19,6 @@ The CLI downloads the matching `v0.1.0` desktop release into
 keeps application settings in the desktop client's existing encrypted store.
 It never reads or prints secret values.
 
-The initial release supports macOS arm64/x64, Windows x64, and Linux x64.
+The initial release supports macOS arm64 and Windows x64.
 The desktop application is currently unsigned, so the operating system may
 show a security warning.

--- a/cli/release-assets.json
+++ b/cli/release-assets.json
@@ -7,20 +7,10 @@
       "executable": "Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb",
       "archive": "zip"
     },
-    "darwin-x64": {
-      "artifact": "nova-audio-agent-0.1.0-macos-x64-app.zip",
-      "executable": "Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb",
-      "archive": "zip"
-    },
     "win32-x64": {
       "artifact": "nova-audio-agent-0.1.0-windows-x64-portable.zip",
       "executable": "Nova Audio Agent Ambient Orb.exe",
       "archive": "zip"
-    },
-    "linux-x64": {
-      "artifact": "nova-audio-agent-0.1.0-linux-x64.AppImage",
-      "executable": "NovaAudioAgent.AppImage",
-      "archive": "file"
     }
   }
 }

--- a/cli/src/runtime.mjs
+++ b/cli/src/runtime.mjs
@@ -301,6 +301,7 @@ export async function ensureDesktop({
   arch = process.arch,
   home,
   fetchImpl = fetch,
+  extractImpl = extractArtifact,
   baseUrl = releaseBaseUrl(),
 } = {}) {
   const target = resolveTarget(platform, arch)
@@ -335,7 +336,7 @@ export async function ensureDesktop({
       const actual = await downloadArtifact(artifactUrl, artifact, {fetchImpl})
       if (!sameDigest(expected, actual)) throw new Error('release checksum mismatch')
       const payload = join(temporary, 'payload')
-      await extractArtifact({artifact, payload, target, platform})
+      await extractImpl({artifact, payload, target, platform})
       await writeFile(join(payload, 'novaaudio-install.json'), `${JSON.stringify({
         schema_version: 1,
         version: PRODUCT_VERSION,

--- a/cli/src/target.mjs
+++ b/cli/src/target.mjs
@@ -10,20 +10,10 @@ const DEFINITIONS = Object.freeze({
     executable: 'Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb',
     archive: 'zip',
   }),
-  'darwin-x64': Object.freeze({
-    artifact: `nova-audio-agent-${PRODUCT_VERSION}-macos-x64-app.zip`,
-    executable: 'Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb',
-    archive: 'zip',
-  }),
   'win32-x64': Object.freeze({
     artifact: `nova-audio-agent-${PRODUCT_VERSION}-windows-x64-portable.zip`,
     executable: 'Nova Audio Agent Ambient Orb.exe',
     archive: 'zip',
-  }),
-  'linux-x64': Object.freeze({
-    artifact: `nova-audio-agent-${PRODUCT_VERSION}-linux-x64.AppImage`,
-    executable: 'NovaAudioAgent.AppImage',
-    archive: 'file',
   }),
 })
 

--- a/cli/test/runtime.test.mjs
+++ b/cli/test/runtime.test.mjs
@@ -3,12 +3,20 @@ import {createHash} from 'node:crypto'
 import {EventEmitter} from 'node:events'
 import {mkdir, mkdtemp, readFile, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
-import {join} from 'node:path'
+import {dirname, join} from 'node:path'
 import {test} from 'node:test'
 
 import {ensureDesktop, inspectDoctor, launchDesktop, parseChecksum} from '../src/runtime.mjs'
 
-const ARTIFACT = 'nova-audio-agent-0.1.0-linux-x64.AppImage'
+const ARTIFACT = 'nova-audio-agent-0.1.0-windows-x64-portable.zip'
+const TARGET_OPTIONS = Object.freeze({platform: 'win32', arch: 'x64'})
+
+async function extractFixture({artifact, payload, target}) {
+  const executable = join(payload, target.executable)
+  await mkdir(dirname(executable), {recursive: true})
+  await writeFile(executable, await readFile(artifact), {mode: 0o700})
+  return executable
+}
 
 test('checksum parser binds a digest to the requested asset', () => {
   const digest = 'a'.repeat(64)
@@ -28,12 +36,12 @@ test('desktop install verifies, atomically caches, and reuses a portable file', 
       ? new Response(`${digest}  ${ARTIFACT}\n`)
       : new Response(bytes)
   }
-  const first = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl})
+  const first = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture})
   assert.deepEqual(await readFile(first.executable), bytes)
   const receipt = JSON.parse(await readFile(join(first.root, 'novaaudio-install.json'), 'utf8'))
   assert.equal(receipt.sha256, digest)
   assert.equal(requests, 2)
-  const second = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl})
+  const second = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture})
   assert.equal(second.executable, first.executable)
   assert.equal(requests, 3)
 })
@@ -45,10 +53,10 @@ test('an online cache is reused only while its receipt matches the current relea
   const fetchImpl = async url => String(url).endsWith('.sha256')
     ? new Response(`${digest}  ${ARTIFACT}\n`)
     : new Response(bytes)
-  const first = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl})
+  const first = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture})
   bytes = Buffer.from('#!/bin/sh\nexit 0\n')
   digest = createHash('sha256').update(bytes).digest('hex')
-  const second = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl})
+  const second = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture})
   assert.equal(second.executable, first.executable)
   assert.deepEqual(await readFile(second.executable), bytes)
   const receipt = JSON.parse(await readFile(join(second.root, 'novaaudio-install.json'), 'utf8'))
@@ -62,9 +70,9 @@ test('a receipt-validated cache remains available when the release host is offli
   const online = async url => String(url).endsWith('.sha256')
     ? new Response(`${digest}  ${ARTIFACT}\n`)
     : new Response(bytes)
-  const installed = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl: online})
+  const installed = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl: online, extractImpl: extractFixture})
   const offline = async () => { throw new Error('offline') }
-  const reused = await ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl: offline})
+  const reused = await ensureDesktop({...TARGET_OPTIONS, home, fetchImpl: offline, extractImpl: extractFixture})
   assert.equal(reused.executable, installed.executable)
 })
 
@@ -74,23 +82,23 @@ test('checksum failure leaves no runnable installation', async () => {
     ? new Response(`${'0'.repeat(64)}  ${ARTIFACT}\n`)
     : new Response('changed')
   await assert.rejects(
-    ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl}),
+    ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture}),
     /checksum mismatch/u,
   )
-  const root = join(home, '.nova-audio-agent/cli/releases/0.1.0/linux-x64')
-  await assert.rejects(readFile(join(root, 'NovaAudioAgent.AppImage')))
+  const root = join(home, '.nova-audio-agent/cli/releases/0.1.0/win32-x64')
+  await assert.rejects(readFile(join(root, 'Nova Audio Agent Ambient Orb.exe')))
 })
 
 test('a failed replacement preserves an existing cache directory', async () => {
   const home = await mkdtemp(join(tmpdir(), 'novaaudio-cli-'))
-  const root = join(home, '.nova-audio-agent/cli/releases/0.1.0/linux-x64')
+  const root = join(home, '.nova-audio-agent/cli/releases/0.1.0/win32-x64')
   await mkdir(root, {recursive: true})
   await writeFile(join(root, 'previous-cache'), 'keep')
   const fetchImpl = async url => String(url).endsWith('.sha256')
     ? new Response(`${'0'.repeat(64)}  ${ARTIFACT}\n`)
     : new Response('changed')
   await assert.rejects(
-    ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl}),
+    ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture}),
     /checksum mismatch/u,
   )
   assert.equal(await readFile(join(root, 'previous-cache'), 'utf8'), 'keep')
@@ -108,8 +116,8 @@ test('concurrent installs serialize and reuse the first verified result', async 
     return new Response(bytes)
   }
   const [first, second] = await Promise.all([
-    ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl}),
-    ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl}),
+    ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture}),
+    ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture}),
   ])
   assert.equal(first.executable, second.executable)
   assert.equal(requests, 3)
@@ -129,19 +137,20 @@ test('an interrupted download leaves no partial executable', async () => {
     }))
   }
   await assert.rejects(
-    ensureDesktop({platform: 'linux', arch: 'x64', home, fetchImpl}),
+    ensureDesktop({...TARGET_OPTIONS, home, fetchImpl, extractImpl: extractFixture}),
     /connection lost/u,
   )
-  const executable = join(home, '.nova-audio-agent/cli/releases/0.1.0/linux-x64/NovaAudioAgent.AppImage')
+  const executable = join(home, '.nova-audio-agent/cli/releases/0.1.0/win32-x64/Nova Audio Agent Ambient Orb.exe')
   await assert.rejects(readFile(executable))
 })
 
 test('doctor exposes only configured secret key names', async () => {
   const home = await mkdtemp(join(tmpdir(), 'novaaudio-cli-'))
-  const settings = join(home, '.config/Nova Audio Agent Ambient Orb/ambient-orb-settings.json')
+  const appData = join(home, 'appdata')
+  const settings = join(appData, 'Nova Audio Agent Ambient Orb/ambient-orb-settings.json')
   await mkdir(join(settings, '..'), {recursive: true})
   await writeFile(settings, JSON.stringify({secrets: {OPENAI_API_KEY: 'secret-value'}}))
-  const report = await inspectDoctor({platform: 'linux', arch: 'x64', home, environment: {}})
+  const report = await inspectDoctor({...TARGET_OPTIONS, home, environment: {APPDATA: appData}})
   assert.deepEqual(report.configuredSecretKeys, ['OPENAI_API_KEY'])
   assert.doesNotMatch(JSON.stringify(report), /secret-value/u)
 })

--- a/cli/test/target.test.mjs
+++ b/cli/test/target.test.mjs
@@ -14,17 +14,17 @@ import {
 test('public version and target matrix are stable', () => {
   assert.equal(PRODUCT_VERSION, '0.1.0')
   assert.equal(resolveTarget('darwin', 'arm64').artifact, 'nova-audio-agent-0.1.0-macos-arm64-app.zip')
-  assert.equal(resolveTarget('darwin', 'x64').artifact, 'nova-audio-agent-0.1.0-macos-x64-app.zip')
   assert.equal(resolveTarget('win32', 'x64').executable, 'Nova Audio Agent Ambient Orb.exe')
-  assert.equal(resolveTarget('linux', 'x64').archive, 'file')
+  assert.throws(() => resolveTarget('darwin', 'x64'), /unsupported platform/u)
+  assert.throws(() => resolveTarget('linux', 'x64'), /unsupported platform/u)
   assert.throws(() => resolveTarget('linux', 'arm64'), /unsupported platform/u)
 })
 
 test('release and settings paths use the documented local roots', () => {
-  const target = resolveTarget('linux', 'x64')
+  const target = resolveTarget('win32', 'x64')
   assert.equal(
     releaseRoot({home: '/tmp/home', target}),
-    join('/tmp/home', '.nova-audio-agent', 'cli', 'releases', '0.1.0', 'linux-x64'),
+    join('/tmp/home', '.nova-audio-agent', 'cli', 'releases', '0.1.0', 'win32-x64'),
   )
   assert.equal(
     desktopSettingsPath({platform: 'linux', home: '/tmp/home', environment: {}}),
@@ -38,7 +38,7 @@ test('published package and release metadata use strict public allowlists', asyn
   const assets = JSON.parse(await readFile(new URL('../release-assets.json', import.meta.url), 'utf8'))
   assert.deepEqual(packageJson.files, ['bin/', 'src/', 'release-assets.json', 'README.md', 'LICENSE'])
   assert.deepEqual(Object.keys(assets.targets).sort(), [
-    'darwin-arm64', 'darwin-x64', 'linux-x64', 'win32-x64',
+    'darwin-arm64', 'win32-x64',
   ])
   for (const [id, entry] of Object.entries(assets.targets)) {
     const {id: resolvedId, ...definition} = resolveTarget(...id.split('-'))

--- a/desktop/ambient-orb/scripts/build-contract.mjs
+++ b/desktop/ambient-orb/scripts/build-contract.mjs
@@ -32,6 +32,7 @@ const BUILD_JAVASCRIPT_FILES = Object.freeze([
   'scripts/sign-mac-with-native-manifest.cjs',
   'scripts/after-sign.cjs',
   'scripts/installed-candidate-smoke.mjs',
+  'scripts/windows-smoke-home.mjs',
   'scripts/collect-release-artifacts.mjs',
   'scripts/generate-pending-release-ledger.mjs',
   'scripts/generate-release-candidate-report.mjs',

--- a/desktop/ambient-orb/scripts/build-contract.mjs
+++ b/desktop/ambient-orb/scripts/build-contract.mjs
@@ -32,6 +32,7 @@ const BUILD_JAVASCRIPT_FILES = Object.freeze([
   'scripts/sign-mac-with-native-manifest.cjs',
   'scripts/after-sign.cjs',
   'scripts/installed-candidate-smoke.mjs',
+  'scripts/run-unsigned-installed-smoke.mjs',
   'scripts/windows-smoke-home.mjs',
   'scripts/collect-release-artifacts.mjs',
   'scripts/generate-pending-release-ledger.mjs',

--- a/desktop/ambient-orb/scripts/installed-candidate-smoke.mjs
+++ b/desktop/ambient-orb/scripts/installed-candidate-smoke.mjs
@@ -3,11 +3,19 @@ import {createHash} from 'node:crypto'
 import {spawn, spawnSync} from 'node:child_process'
 import {createServer as createHttpsServer} from 'node:https'
 import {copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, stat} from 'node:fs/promises'
-import {homedir, tmpdir} from 'node:os'
 import {isAbsolute, join, posix, resolve, win32} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import {WebSocket, WebSocketServer} from 'ws'
+import {
+  candidateScratchParent,
+  prepareWindowsSmokeHomeOwnership,
+} from './windows-smoke-home.mjs'
+
+export {
+  candidateScratchParent,
+  prepareWindowsSmokeHomeOwnership,
+} from './windows-smoke-home.mjs'
 
 export const RELEASE_SMOKE_MODE = 'installed-candidate-v1'
 export const CAMERA_CAPABILITY_PENDING = 'camera-file-integration: chromium_codec_unavailable'
@@ -21,55 +29,6 @@ export const SCRATCH_REMOVAL_OPTIONS = Object.freeze({
   maxRetries: 100,
   retryDelay: 50,
 })
-
-export function candidateScratchParent({
-  platform = process.platform,
-  home = homedir(),
-  temporary = tmpdir(),
-} = {}) {
-  const parent = platform === 'win32' ? home : temporary
-  const pathApi = platform === 'win32' ? win32 : posix
-  if (typeof parent !== 'string' || !pathApi.isAbsolute(parent)) {
-    throw new Error('installed_candidate_invalid')
-  }
-  return pathApi.resolve(parent)
-}
-
-export function prepareWindowsSmokeHomeOwnership({
-  platform = process.platform,
-  home,
-  environment,
-  run = spawnSync,
-}) {
-  if (platform !== 'win32') return
-  const systemRoot = environment?.SystemRoot ?? environment?.WINDIR
-  if (typeof home !== 'string' || !win32.isAbsolute(home)
-    || typeof systemRoot !== 'string' || !win32.isAbsolute(systemRoot)) {
-    throw new Error('installed_candidate_invalid')
-  }
-  const options = {
-    env: environment,
-    encoding: 'utf8',
-    windowsHide: true,
-    timeout: 10_000,
-    maxBuffer: OUTPUT_LIMIT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }
-  const identity = run(win32.join(systemRoot, 'System32', 'whoami.exe'), [
-    '/user', '/fo', 'csv', '/nh',
-  ], options)
-  const match = typeof identity?.stdout === 'string'
-    ? /^"[^"\r\n]{1,256}","(S-1-(?:[0-9]+-){1,15}[0-9]+)"\r?\n?$/u.exec(identity.stdout)
-    : null
-  if (identity?.status !== 0 || identity?.error !== undefined || identity?.signal !== null
-    || match === null) throw new Error('installed_candidate_invalid')
-  const ownership = run(win32.join(systemRoot, 'System32', 'icacls.exe'), [
-    home, '/setowner', `*${match[1]}`, '/Q',
-  ], options)
-  if (ownership?.status !== 0 || ownership?.error !== undefined || ownership?.signal !== null) {
-    throw new Error('installed_candidate_invalid')
-  }
-}
 
 const DEFAULT_SIGNER_WORKFLOW = 'deepnovacore/NovaAudioAgent/.github/workflows/release-candidate.yml'
 const SIGNER_WORKFLOWS = new Set([

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -41,6 +41,18 @@ mkdirSync(stateRoot, {mode: 0o700})
 mkdirSync(managedRoot, {mode: 0o700})
 chmodSync(scratch, 0o700)
 
+function protectScratchDirectory(host, childPath, name) {
+  let parent = null
+  let child = null
+  try {
+    parent = host.directoryHandles.open(scratch)
+    child = host.directoryHandles.open(childPath)
+    assert.equal(host.protectDirectoryAt(parent.fd, name, child.fd), true)
+  } finally {
+    try { child?.close() } finally { parent?.close() }
+  }
+}
+
 let stage = 'load_runtime'
 void (async () => {
   const [configModule, hostConfigModule, factoryModule, productionHostModule, clockModule] = (
@@ -72,6 +84,11 @@ void (async () => {
   assert.equal(projectHost.transportFactory.available, true, 'packaged_codex_transport_unavailable')
   stage = 'host_project_native'
   assert.notEqual(projectHost.projectHost, null, 'packaged_project_native_unavailable')
+  if (process.platform === 'win32') {
+    stage = 'host_project_scratch'
+    protectScratchDirectory(projectHost.projectHost, stateRoot, 'state')
+    protectScratchDirectory(projectHost.projectHost, managedRoot, 'managed')
+  }
   stage = 'host_project_config'
   const projectConfig = hostConfigModule.resolveCodexHostConfig(projectSettings, projectHost.catalog)
   assert.notEqual(projectConfig, null, 'packaged_codex_config_unavailable')

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -43,6 +43,51 @@ const managedRoot = join(projectRoot, 'workspaces')
 chmodSync(scratch, 0o700)
 
 let stage = 'load_runtime'
+
+function directoryLabel(target) {
+  if (target === scratch) return 'home'
+  if (target === projectRoot) return 'root'
+  if (target === stateRoot) return 'state'
+  if (target === managedRoot) return 'managed'
+  if (target === join(managedRoot, 'default')) return 'workspace'
+  return 'external'
+}
+
+function childLabel(name) {
+  if (name === '.nova-audio-agent') return 'root'
+  if (name === 'state') return 'state'
+  if (name === 'workspaces') return 'managed'
+  if (name === 'default') return 'workspace'
+  return 'external'
+}
+
+function diagnosticDirectoryHost(host) {
+  return Object.freeze({
+    ...host,
+    directoryHandles: Object.freeze({
+      open(target) {
+        stage = `host_project_directories_open_${directoryLabel(target)}`
+        return host.directoryHandles.open(target)
+      },
+    }),
+    rootFiles: Object.freeze({
+      ...host.rootFiles,
+      mkdirAt(root, name) {
+        stage = `host_project_directories_create_${childLabel(name)}`
+        return host.rootFiles.mkdirAt(root, name)
+      },
+    }),
+    mkdirPrivateAt(root, name) {
+      stage = `host_project_directories_create_${childLabel(name)}`
+      return host.mkdirPrivateAt(root, name)
+    },
+    protectDirectoryAt(root, name, child) {
+      stage = `host_project_directories_protect_${childLabel(name)}`
+      return host.protectDirectoryAt(root, name, child)
+    },
+  })
+}
+
 void (async () => {
   const [
     configModule,
@@ -83,11 +128,12 @@ void (async () => {
   assert.notEqual(projectHost.projectHost, null, 'packaged_project_native_unavailable')
   if (process.platform === 'win32') {
     stage = 'host_project_directories'
+    const directoryHost = diagnosticDirectoryHost(projectHost.projectHost)
     await projectDirectoriesModule.ensurePrivateProjectDirectories({
       config: {root: projectRoot, stateRoot, managedRoot, workspace},
       home: scratch,
       platform: process.platform,
-      nativeHost: projectHost.projectHost,
+      nativeHost: directoryHost,
       pathApi: path,
       mkdir,
     })

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -2,9 +2,11 @@
 
 const assert = require('node:assert/strict')
 const {randomUUID} = require('node:crypto')
-const {chmodSync, mkdtempSync, mkdirSync, realpathSync, rmSync} = require('node:fs')
+const {chmodSync, mkdtempSync, realpathSync, rmSync} = require('node:fs')
+const {mkdir} = require('node:fs/promises')
 const {tmpdir} = require('node:os')
-const {isAbsolute, join, resolve, sep} = require('node:path')
+const path = require('node:path')
+const {isAbsolute, join, resolve, sep} = path
 const {pathToFileURL} = require('node:url')
 
 const SAFE_PREFLIGHT_CODES = new Set([
@@ -35,35 +37,30 @@ const runtimeRoot = resolve(
 )
 assert.ok(runtimeRoot.includes(`${sep}app.asar${sep}`), 'packaged_codex_host_invalid')
 const scratch = realpathSync(mkdtempSync(join(tmpdir(), 'nova-packaged-codex-composition-')))
-const stateRoot = join(scratch, 'state')
-const managedRoot = join(scratch, 'managed')
-mkdirSync(stateRoot, {mode: 0o700})
-mkdirSync(managedRoot, {mode: 0o700})
+const projectRoot = join(scratch, '.nova-audio-agent')
+const stateRoot = join(projectRoot, 'state')
+const managedRoot = join(projectRoot, 'workspaces')
 chmodSync(scratch, 0o700)
-
-function protectScratchDirectory(host, childPath, name) {
-  let parent = null
-  let child = null
-  try {
-    parent = host.directoryHandles.open(scratch)
-    child = host.directoryHandles.open(childPath)
-    assert.equal(host.protectDirectoryAt(parent.fd, name, child.fd), true)
-  } finally {
-    try { child?.close() } finally { parent?.close() }
-  }
-}
 
 let stage = 'load_runtime'
 void (async () => {
-  const [configModule, hostConfigModule, factoryModule, productionHostModule, clockModule] = (
-    await Promise.all([
+  const [
+    configModule,
+    hostConfigModule,
+    factoryModule,
+    productionHostModule,
+    clockModule,
+    projectDirectoriesModule,
+  ] = await Promise.all([
+    ...[
       'config.js',
       'codex-host-config.js',
       'codex-factory.js',
       'codex-production-host.js',
       'clock.js',
-    ].map(name => import(pathToFileURL(resolve(runtimeRoot, name)).href)))
-  )
+    ].map(name => pathToFileURL(resolve(runtimeRoot, name)).href),
+    pathToFileURL(resolve(resourcesRoot, 'app.asar', 'src/main/project-directories.mjs')).href,
+  ].map(specifier => import(specifier)))
   stage = 'settings_project'
   const baseEnvironment = {
     ...process.env,
@@ -79,15 +76,24 @@ void (async () => {
     NOVA_AUDIO_AGENT_CODEX_MANAGED_ROOT: managedRoot,
   })
   stage = 'host_project'
-  const projectHost = productionHostModule.createProductionCodexHost(projectSettings)
+  const projectHost = productionHostModule.createProductionCodexHost(projectSettings, {
+    environment: baseEnvironment,
+    homeDirectory: scratch,
+  })
   stage = 'host_project_transport'
   assert.equal(projectHost.transportFactory.available, true, 'packaged_codex_transport_unavailable')
   stage = 'host_project_native'
   assert.notEqual(projectHost.projectHost, null, 'packaged_project_native_unavailable')
   if (process.platform === 'win32') {
-    stage = 'host_project_scratch'
-    protectScratchDirectory(projectHost.projectHost, stateRoot, 'state')
-    protectScratchDirectory(projectHost.projectHost, managedRoot, 'managed')
+    stage = 'host_project_directories'
+    await projectDirectoriesModule.ensurePrivateProjectDirectories({
+      config: {root: projectRoot, stateRoot, managedRoot, workspace},
+      home: scratch,
+      platform: process.platform,
+      nativeHost: projectHost.projectHost,
+      pathApi: path,
+      mkdir,
+    })
   }
   stage = 'host_project_config'
   const projectConfig = hostConfigModule.resolveCodexHostConfig(projectSettings, projectHost.catalog)

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -122,7 +122,16 @@ void (async () => {
     'packaged_project_missing_host_did_not_fail_closed',
   )
   process.stdout.write('packaged production Codex composition passed\n')
-})().catch(() => {
+})().catch(error => {
+  if (
+    stage === 'resource_project'
+    && typeof error?.code === 'string'
+    && [
+      'codex_host_unavailable',
+      'codex_project_host_unsupported',
+      'codex_project_state_invalid',
+    ].includes(error.code)
+  ) stage = `${stage}_${error.code}`
   process.stderr.write(`packaged production Codex composition rejected stage=${stage}\n`)
   process.exitCode = 1
 }).finally(() => {

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -4,7 +4,6 @@ const assert = require('node:assert/strict')
 const {randomUUID} = require('node:crypto')
 const {chmodSync, mkdtempSync, realpathSync, rmSync} = require('node:fs')
 const {mkdir} = require('node:fs/promises')
-const {tmpdir} = require('node:os')
 const path = require('node:path')
 const {isAbsolute, join, resolve, sep} = path
 const {pathToFileURL} = require('node:url')
@@ -36,20 +35,15 @@ const runtimeRoot = resolve(
   'src',
 )
 assert.ok(runtimeRoot.includes(`${sep}app.asar${sep}`), 'packaged_codex_host_invalid')
-const scratch = realpathSync(mkdtempSync(join(tmpdir(), 'nova-packaged-codex-composition-')))
-const projectRoot = join(scratch, '.nova-audio-agent')
-const stateRoot = join(projectRoot, 'state')
-const managedRoot = join(projectRoot, 'workspaces')
-chmodSync(scratch, 0o700)
-
 let stage = 'load_runtime'
+let scratch = null
 
-function directoryLabel(target) {
-  if (target === scratch) return 'home'
-  if (target === projectRoot) return 'root'
-  if (target === stateRoot) return 'state'
-  if (target === managedRoot) return 'managed'
-  if (target === join(managedRoot, 'default')) return 'workspace'
+function directoryLabel(target, directories) {
+  if (target === directories.scratch) return 'home'
+  if (target === directories.projectRoot) return 'root'
+  if (target === directories.stateRoot) return 'state'
+  if (target === directories.managedRoot) return 'managed'
+  if (target === join(directories.managedRoot, 'default')) return 'workspace'
   return 'external'
 }
 
@@ -61,12 +55,12 @@ function childLabel(name) {
   return 'external'
 }
 
-function diagnosticDirectoryHost(host) {
+function diagnosticDirectoryHost(host, directories) {
   return Object.freeze({
     ...host,
     directoryHandles: Object.freeze({
       open(target) {
-        stage = `host_project_directories_open_${directoryLabel(target)}`
+        stage = `host_project_directories_open_${directoryLabel(target, directories)}`
         return host.directoryHandles.open(target)
       },
     }),
@@ -96,6 +90,7 @@ void (async () => {
     productionHostModule,
     clockModule,
     projectDirectoriesModule,
+    smokeHomeModule,
   ] = await Promise.all([
     ...[
       'config.js',
@@ -105,7 +100,21 @@ void (async () => {
       'clock.js',
     ].map(name => pathToFileURL(resolve(runtimeRoot, name)).href),
     pathToFileURL(resolve(resourcesRoot, 'app.asar', 'src/main/project-directories.mjs')).href,
+    pathToFileURL(resolve(__dirname, 'windows-smoke-home.mjs')).href,
   ].map(specifier => import(specifier)))
+  stage = 'host_project_home'
+  scratch = realpathSync(mkdtempSync(join(
+    smokeHomeModule.candidateScratchParent(),
+    'nova-packaged-codex-composition-',
+  )))
+  chmodSync(scratch, 0o700)
+  smokeHomeModule.prepareWindowsSmokeHomeOwnership({
+    home: scratch,
+    environment: process.env,
+  })
+  const projectRoot = join(scratch, '.nova-audio-agent')
+  const stateRoot = join(projectRoot, 'state')
+  const managedRoot = join(projectRoot, 'workspaces')
   stage = 'settings_project'
   const baseEnvironment = {
     ...process.env,
@@ -128,7 +137,9 @@ void (async () => {
   assert.notEqual(projectHost.projectHost, null, 'packaged_project_native_unavailable')
   if (process.platform === 'win32') {
     stage = 'host_project_directories'
-    const directoryHost = diagnosticDirectoryHost(projectHost.projectHost)
+    const directoryHost = diagnosticDirectoryHost(projectHost.projectHost, {
+      scratch, projectRoot, stateRoot, managedRoot,
+    })
     await projectDirectoriesModule.ensurePrivateProjectDirectories({
       config: {root: projectRoot, stateRoot, managedRoot, workspace},
       home: scratch,
@@ -201,5 +212,5 @@ void (async () => {
   process.stderr.write(`packaged production Codex composition rejected stage=${stage}\n`)
   process.exitCode = 1
 }).finally(() => {
-  rmSync(scratch, {recursive: true, force: true})
+  if (scratch !== null) rmSync(scratch, {recursive: true, force: true})
 })

--- a/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
+++ b/desktop/ambient-orb/scripts/packaged-production-codex-smoke.cjs
@@ -76,10 +76,7 @@ void (async () => {
     NOVA_AUDIO_AGENT_CODEX_MANAGED_ROOT: managedRoot,
   })
   stage = 'host_project'
-  const projectHost = productionHostModule.createProductionCodexHost(projectSettings, {
-    environment: baseEnvironment,
-    homeDirectory: scratch,
-  })
+  const projectHost = productionHostModule.createProductionCodexHost(projectSettings)
   stage = 'host_project_transport'
   assert.equal(projectHost.transportFactory.available, true, 'packaged_codex_transport_unavailable')
   stage = 'host_project_native'

--- a/desktop/ambient-orb/scripts/prepare-release-smoke-kit.mjs
+++ b/desktop/ambient-orb/scripts/prepare-release-smoke-kit.mjs
@@ -15,6 +15,8 @@ await generateReleaseSmokeCertificate({
 await Promise.all([
   cp(resolve(packageRoot, 'scripts/installed-candidate-smoke.mjs'),
     resolve(output, 'scripts/installed-candidate-smoke.mjs')),
+  cp(resolve(packageRoot, 'scripts/run-unsigned-installed-smoke.mjs'),
+    resolve(output, 'scripts/run-unsigned-installed-smoke.mjs')),
   cp(resolve(packageRoot, 'scripts/windows-smoke-home.mjs'),
     resolve(output, 'scripts/windows-smoke-home.mjs')),
   cp(resolve(repositoryRoot, 'node_modules/ws'), resolve(output, 'node_modules/ws'), {recursive: true}),

--- a/desktop/ambient-orb/scripts/prepare-release-smoke-kit.mjs
+++ b/desktop/ambient-orb/scripts/prepare-release-smoke-kit.mjs
@@ -15,6 +15,8 @@ await generateReleaseSmokeCertificate({
 await Promise.all([
   cp(resolve(packageRoot, 'scripts/installed-candidate-smoke.mjs'),
     resolve(output, 'scripts/installed-candidate-smoke.mjs')),
+  cp(resolve(packageRoot, 'scripts/windows-smoke-home.mjs'),
+    resolve(output, 'scripts/windows-smoke-home.mjs')),
   cp(resolve(repositoryRoot, 'node_modules/ws'), resolve(output, 'node_modules/ws'), {recursive: true}),
   cp(resolve(repositoryRoot, 'assets/demos/cat-sofa-guard/cat-sofa-guard.mp4'),
     resolve(output, 'cat-sofa-guard.mp4')),

--- a/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
+++ b/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
@@ -10,7 +10,7 @@ const PREFLIGHT_FAILURES = [
 ]
 const FAILURE_STAGES = new Set([
   'load_runtime', 'settings_project', 'host_project', 'host_project_transport',
-  'host_project_native', 'host_project_scratch', 'host_project_config', 'resource_project',
+  'host_project_native', 'host_project_directories', 'host_project_config', 'resource_project',
   'resource_project_codex_host_unavailable',
   'resource_project_codex_project_host_unsupported',
   'resource_project_codex_project_state_invalid',

--- a/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
+++ b/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
@@ -11,6 +11,9 @@ const PREFLIGHT_FAILURES = [
 const FAILURE_STAGES = new Set([
   'load_runtime', 'settings_project', 'host_project', 'host_project_transport',
   'host_project_native', 'host_project_config', 'resource_project',
+  'resource_project_codex_host_unavailable',
+  'resource_project_codex_project_host_unsupported',
+  'resource_project_codex_project_state_invalid',
   'start_project', 'close_project', 'resource_without_project_host',
   ...PREFLIGHT_FAILURES.map(code => `start_project_${code}`),
 ])

--- a/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
+++ b/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
@@ -8,6 +8,11 @@ const PREFLIGHT_FAILURES = [
   'sandbox_failed', 'spawn_failed', 'stderr_too_large', 'unsupported_protocol',
   'unsupported_version', 'workspace_invalid', 'workspace_root_mismatch',
 ]
+const DIRECTORY_FAILURE_STAGES = ['open', 'create', 'protect'].flatMap(operation => (
+  ['home', 'root', 'state', 'managed', 'workspace', 'external'].map(directory => (
+    `host_project_directories_${operation}_${directory}`
+  ))
+))
 const FAILURE_STAGES = new Set([
   'load_runtime', 'settings_project', 'host_project', 'host_project_transport',
   'host_project_native', 'host_project_directories', 'host_project_config', 'resource_project',
@@ -15,6 +20,7 @@ const FAILURE_STAGES = new Set([
   'resource_project_codex_project_host_unsupported',
   'resource_project_codex_project_state_invalid',
   'start_project', 'close_project', 'resource_without_project_host',
+  ...DIRECTORY_FAILURE_STAGES,
   ...PREFLIGHT_FAILURES.map(code => `start_project_${code}`),
 ])
 

--- a/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
+++ b/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
@@ -10,7 +10,7 @@ const PREFLIGHT_FAILURES = [
 ]
 const FAILURE_STAGES = new Set([
   'load_runtime', 'settings_project', 'host_project', 'host_project_transport',
-  'host_project_native', 'host_project_config', 'resource_project',
+  'host_project_native', 'host_project_scratch', 'host_project_config', 'resource_project',
   'resource_project_codex_host_unavailable',
   'resource_project_codex_project_host_unsupported',
   'resource_project_codex_project_state_invalid',

--- a/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
+++ b/desktop/ambient-orb/scripts/run-packaged-codex-smoke.mjs
@@ -15,7 +15,8 @@ const DIRECTORY_FAILURE_STAGES = ['open', 'create', 'protect'].flatMap(operation
 ))
 const FAILURE_STAGES = new Set([
   'load_runtime', 'settings_project', 'host_project', 'host_project_transport',
-  'host_project_native', 'host_project_directories', 'host_project_config', 'resource_project',
+  'host_project_native', 'host_project_home', 'host_project_directories',
+  'host_project_config', 'resource_project',
   'resource_project_codex_host_unavailable',
   'resource_project_codex_project_host_unsupported',
   'resource_project_codex_project_state_invalid',

--- a/desktop/ambient-orb/scripts/verify-github-release-attestations.mjs
+++ b/desktop/ambient-orb/scripts/verify-github-release-attestations.mjs
@@ -39,12 +39,8 @@ const RELEASE_FILE_PREFIX = `nova-audio-agent-${RELEASE_VERSION}`
 export const RELEASE_ARTIFACT_FILES = Object.freeze({
   'darwin-arm64:app': `${RELEASE_FILE_PREFIX}-macos-arm64-app.zip`,
   'darwin-arm64:dmg': `${RELEASE_FILE_PREFIX}-macos-arm64.dmg`,
-  'darwin-x64:app': `${RELEASE_FILE_PREFIX}-macos-x64-app.zip`,
-  'darwin-x64:dmg': `${RELEASE_FILE_PREFIX}-macos-x64.dmg`,
   'win32-x64:portable': `${RELEASE_FILE_PREFIX}-windows-x64-portable.zip`,
   'win32-x64:nsis': `${RELEASE_FILE_PREFIX}-windows-x64.exe`,
-  'linux-x64-gnu:appimage': `${RELEASE_FILE_PREFIX}-linux-x64.AppImage`,
-  'linux-x64-gnu:deb': `${RELEASE_FILE_PREFIX}-linux-x64.deb`,
 })
 
 export class ReleaseAttestationError extends Error {

--- a/desktop/ambient-orb/scripts/verify-release-evidence.mjs
+++ b/desktop/ambient-orb/scripts/verify-release-evidence.mjs
@@ -38,9 +38,7 @@ const EVIDENCE_CLASSES = Object.freeze({
 
 const ARTIFACT_TARGETS = new Set([
   'darwin-arm64:app', 'darwin-arm64:dmg',
-  'darwin-x64:app', 'darwin-x64:dmg',
   'win32-x64:portable', 'win32-x64:nsis',
-  'linux-x64-gnu:appimage', 'linux-x64-gnu:deb',
 ])
 const RECORD_KEYS = Object.freeze([
   'schema_version', 'gate_id', 'evidence_class', 'target', 'artifact_sha256',

--- a/desktop/ambient-orb/scripts/windows-smoke-home.mjs
+++ b/desktop/ambient-orb/scripts/windows-smoke-home.mjs
@@ -1,0 +1,54 @@
+import {spawnSync} from 'node:child_process'
+import {homedir, tmpdir} from 'node:os'
+import {posix, win32} from 'node:path'
+
+const OUTPUT_LIMIT = 64 * 1024
+
+export function candidateScratchParent({
+  platform = process.platform,
+  home = homedir(),
+  temporary = tmpdir(),
+} = {}) {
+  const parent = platform === 'win32' ? home : temporary
+  const pathApi = platform === 'win32' ? win32 : posix
+  if (typeof parent !== 'string' || !pathApi.isAbsolute(parent)) {
+    throw new Error('installed_candidate_invalid')
+  }
+  return pathApi.resolve(parent)
+}
+
+export function prepareWindowsSmokeHomeOwnership({
+  platform = process.platform,
+  home,
+  environment,
+  run = spawnSync,
+}) {
+  if (platform !== 'win32') return
+  const systemRoot = environment?.SystemRoot ?? environment?.WINDIR
+  if (typeof home !== 'string' || !win32.isAbsolute(home)
+    || typeof systemRoot !== 'string' || !win32.isAbsolute(systemRoot)) {
+    throw new Error('installed_candidate_invalid')
+  }
+  const options = {
+    env: environment,
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 10_000,
+    maxBuffer: OUTPUT_LIMIT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }
+  const identity = run(win32.join(systemRoot, 'System32', 'whoami.exe'), [
+    '/user', '/fo', 'csv', '/nh',
+  ], options)
+  const match = typeof identity?.stdout === 'string'
+    ? /^"[^"\r\n]{1,256}","(S-1-(?:[0-9]+-){1,15}[0-9]+)"\r?\n?$/u.exec(identity.stdout)
+    : null
+  if (identity?.status !== 0 || identity?.error !== undefined || identity?.signal !== null
+    || match === null) throw new Error('installed_candidate_invalid')
+  const ownership = run(win32.join(systemRoot, 'System32', 'icacls.exe'), [
+    home, '/setowner', `*${match[1]}`, '/Q',
+  ], options)
+  if (ownership?.status !== 0 || ownership?.error !== undefined || ownership?.signal !== null) {
+    throw new Error('installed_candidate_invalid')
+  }
+}

--- a/desktop/ambient-orb/test/builder-config.test.mjs
+++ b/desktop/ambient-orb/test/builder-config.test.mjs
@@ -49,6 +49,7 @@ const EXPECTED_BUILD_SCRIPTS = [
   'scripts/sign-mac-with-native-manifest.cjs',
   'scripts/after-sign.cjs',
   'scripts/installed-candidate-smoke.mjs',
+  'scripts/windows-smoke-home.mjs',
   'scripts/collect-release-artifacts.mjs',
   'scripts/generate-pending-release-ledger.mjs',
   'scripts/generate-release-candidate-report.mjs',

--- a/desktop/ambient-orb/test/builder-config.test.mjs
+++ b/desktop/ambient-orb/test/builder-config.test.mjs
@@ -49,6 +49,7 @@ const EXPECTED_BUILD_SCRIPTS = [
   'scripts/sign-mac-with-native-manifest.cjs',
   'scripts/after-sign.cjs',
   'scripts/installed-candidate-smoke.mjs',
+  'scripts/run-unsigned-installed-smoke.mjs',
   'scripts/windows-smoke-home.mjs',
   'scripts/collect-release-artifacts.mjs',
   'scripts/generate-pending-release-ledger.mjs',

--- a/desktop/ambient-orb/test/installed-candidate-smoke.test.mjs
+++ b/desktop/ambient-orb/test/installed-candidate-smoke.test.mjs
@@ -119,12 +119,8 @@ test('installed candidate plans use native install or mount boundaries for every
   const matrix = [
     ['darwin-arm64:app', 'nova-audio-agent-0.1.0-macos-arm64-app.zip', '/private/smoke/install/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb', '/private/smoke/install'],
     ['darwin-arm64:dmg', 'nova-audio-agent-0.1.0-macos-arm64.dmg', '/private/smoke/mount/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb', '/private/smoke/mount/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb'],
-    ['darwin-x64:app', 'nova-audio-agent-0.1.0-macos-x64-app.zip', '/private/smoke/install/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb', '/private/smoke/install'],
-    ['darwin-x64:dmg', 'nova-audio-agent-0.1.0-macos-x64.dmg', '/private/smoke/mount/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb', '/private/smoke/mount/Nova Audio Agent Ambient Orb.app/Contents/MacOS/Nova Audio Agent Ambient Orb'],
     ['win32-x64:portable', 'nova-audio-agent-0.1.0-windows-x64-portable.zip', '/private/smoke/install/Nova Audio Agent Ambient Orb.exe', '/private/smoke/install'],
     ['win32-x64:nsis', 'nova-audio-agent-0.1.0-windows-x64.exe', '/private/smoke/install/Nova Audio Agent Ambient Orb.exe', '/private/smoke/install'],
-    ['linux-x64-gnu:appimage', 'nova-audio-agent-0.1.0-linux-x64.AppImage', '/private/smoke/install/squashfs-root/AppRun', '/private/smoke/install'],
-    ['linux-x64-gnu:deb', 'nova-audio-agent-0.1.0-linux-x64.deb', '/usr/bin/nova-ambient-orb', '/usr/bin/nova-ambient-orb'],
   ]
   for (const [target, artifactName, executable, residue] of matrix) {
     const plan = candidateInstallPlan({target, artifact: `${root}/${artifactName}`, scratch: root})
@@ -148,8 +144,8 @@ test('Windows native installer actions allow enough time for cold CI extraction'
   assert.equal(plan.uninstall[0].timeoutMs, NATIVE_INSTALLER_SETTLE_MS)
 })
 
-test('downloaded macOS release DMGs must verify before they can be mounted', () => {
-  for (const target of ['darwin-arm64:dmg', 'darwin-x64:dmg']) {
+test('downloaded macOS release DMG must verify before it can be mounted', () => {
+  for (const target of ['darwin-arm64:dmg']) {
     const artifact = `/private/candidate/${target}.dmg`
     const plan = candidateInstallPlan({target, artifact, scratch: '/private/scratch'})
     assert.deepEqual(plan.install.slice(0, 2), [

--- a/desktop/ambient-orb/test/installed-candidate-smoke.test.mjs
+++ b/desktop/ambient-orb/test/installed-candidate-smoke.test.mjs
@@ -589,13 +589,13 @@ test('release workflow downloads exact candidates into checkout-free smoke jobs'
   const workflow = await readFile(new URL('../../../.github/workflows/release-candidate.yml', import.meta.url), 'utf8')
   assert.match(workflow, /installed-candidate-smoke/u)
   assert.match(workflow, /actions\/download-artifact@v4/u)
-  assert.match(workflow, /installed-candidate-smoke\.mjs/u)
-  assert.match(workflow, /attest-build-provenance@v3/u)
-  assert.match(workflow, /id-token: write/u)
+  assert.match(workflow, /run-unsigned-installed-smoke\.mjs/u)
+  assert.doesNotMatch(workflow, /attest-build-provenance|id-token:|attestations:/u)
   const smokeStart = workflow.indexOf('  installed-candidate-smoke:')
   const smokeJob = workflow.slice(smokeStart, workflow.indexOf('\n  pending-candidate-ledger:', smokeStart))
   assert.doesNotMatch(smokeJob, /actions\/checkout/u)
   assert.doesNotMatch(smokeJob, /continue-on-error|\|\| true/u)
+  assert.doesNotMatch(smokeJob, /--commit|--signer-workflow|GH_TOKEN/u)
 })
 
 test('installed candidate smoke cold-starts every packaged target through config mode', async () => {

--- a/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
+++ b/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
@@ -71,6 +71,16 @@ test('packaged Codex smoke proves missing project-native authority fails closed'
   assert.doesNotMatch(source, /assert\.equal\(liveResource\.mode, 'live'/u)
 })
 
+test('packaged Codex smoke protects its custom Windows project roots before opening them', async () => {
+  const source = await readFile(
+    resolve(import.meta.dirname, '../scripts/packaged-production-codex-smoke.cjs'),
+    'utf8',
+  )
+  assert.match(source, /process\.platform === 'win32'/u)
+  assert.match(source, /protectScratchDirectory\(projectHost\.projectHost, stateRoot, 'state'\)/u)
+  assert.match(source, /protectScratchDirectory\(projectHost\.projectHost, managedRoot, 'managed'\)/u)
+})
+
 test('local release Codex smoke uses the fixed repository root without caller paths', () => {
   const workspace = releaseCandidateWorkspace({})
   assert.equal(workspace, resolve(fileURLToPath(new URL('../../..', import.meta.url))))

--- a/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
+++ b/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
@@ -71,14 +71,16 @@ test('packaged Codex smoke proves missing project-native authority fails closed'
   assert.doesNotMatch(source, /assert\.equal\(liveResource\.mode, 'live'/u)
 })
 
-test('packaged Codex smoke protects its custom Windows project roots before opening them', async () => {
+test('packaged Codex smoke bootstraps its custom Windows home through desktop authority', async () => {
   const source = await readFile(
     resolve(import.meta.dirname, '../scripts/packaged-production-codex-smoke.cjs'),
     'utf8',
   )
   assert.match(source, /process\.platform === 'win32'/u)
-  assert.match(source, /protectScratchDirectory\(projectHost\.projectHost, stateRoot, 'state'\)/u)
-  assert.match(source, /protectScratchDirectory\(projectHost\.projectHost, managedRoot, 'managed'\)/u)
+  assert.match(source, /ensurePrivateProjectDirectories/u)
+  assert.match(source, /config: \{root: projectRoot, stateRoot, managedRoot, workspace\}/u)
+  assert.match(source, /homeDirectory: scratch/u)
+  assert.doesNotMatch(source, /protectScratchDirectory/u)
 })
 
 test('local release Codex smoke uses the fixed repository root without caller paths', () => {

--- a/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
+++ b/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
@@ -55,8 +55,13 @@ test('packaged Codex failures expose only one closed stage code', () => {
     parsePackagedCodexFailure('packaged production Codex composition rejected stage=resource_project_codex_project_state_invalid\n'),
     'resource_project_codex_project_state_invalid',
   )
+  assert.equal(
+    parsePackagedCodexFailure('packaged production Codex composition rejected stage=host_project_directories_protect_managed\n'),
+    'host_project_directories_protect_managed',
+  )
   for (const value of [
     'packaged production Codex composition rejected stage=private/path\n',
+    'packaged production Codex composition rejected stage=host_project_directories_protect_secret\n',
     'raw private detail\n',
     '',
   ]) assert.equal(parsePackagedCodexFailure(value), 'unknown')

--- a/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
+++ b/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
@@ -79,7 +79,7 @@ test('packaged Codex smoke bootstraps its custom Windows home through desktop au
   assert.match(source, /process\.platform === 'win32'/u)
   assert.match(source, /ensurePrivateProjectDirectories/u)
   assert.match(source, /config: \{root: projectRoot, stateRoot, managedRoot, workspace\}/u)
-  assert.match(source, /homeDirectory: scratch/u)
+  assert.doesNotMatch(source, /homeDirectory:\s*scratch/u)
   assert.doesNotMatch(source, /protectScratchDirectory/u)
 })
 

--- a/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
+++ b/desktop/ambient-orb/test/packaged-codex-smoke.test.mjs
@@ -51,6 +51,10 @@ test('packaged Codex failures expose only one closed stage code', () => {
     parsePackagedCodexFailure('packaged production Codex composition rejected stage=start_project_sandbox_failed\n'),
     'start_project_sandbox_failed',
   )
+  assert.equal(
+    parsePackagedCodexFailure('packaged production Codex composition rejected stage=resource_project_codex_project_state_invalid\n'),
+    'resource_project_codex_project_state_invalid',
+  )
   for (const value of [
     'packaged production Codex composition rejected stage=private/path\n',
     'raw private detail\n',
@@ -77,6 +81,7 @@ test('release-candidate workflow makes packaged Codex composition a required tar
   const workflow = await readFile(resolve(import.meta.dirname, '../../../.github/workflows/release-candidate.yml'), 'utf8')
   assert.match(workflow, /@openai\/codex@0\.147\.0/u)
   assert.match(workflow, /smoke:packaged-codex:ci/u)
+  assert.match(workflow, /NOVA_RELEASE_INSPECTION_DIAGNOSTICS: "1"/u)
   assert.doesNotMatch(workflow, /\/opt\/homebrew\/bin\/codex|\/usr\/local\/bin\/codex|C:\\nova-tools\\codex\.exe/u)
   assert.doesNotMatch(workflow, /continue-on-error|smoke:packaged-codex[^\n]*\|\|/u)
 })

--- a/desktop/ambient-orb/test/release-completion.test.mjs
+++ b/desktop/ambient-orb/test/release-completion.test.mjs
@@ -111,7 +111,13 @@ test('release candidate explicitly builds unsigned bytes and keeps trust-bound s
   assert.doesNotMatch(workflow, /attest-build-provenance|id-token:|attestations:/u)
   assert.match(workflow, /generate:pending-release-ledger/u)
   assert.match(workflow, /node desktop\/ambient-orb\/node_modules\/electron\/install\.js/u)
-  assert.match(workflow, /npm run test:runtime\n\s+[^\n]*\n\s+[^\n]*\n\s+[^\n]*\n\s+if: runner\.os != 'Windows'/u)
+  assert.match(
+    workflow,
+    /npm run test:runtime\n\s+[^\n]*\n\s+[^\n]*\n\s+[^\n]*\n\s+if: .*runner\.os != 'Windows'/u,
+  )
+  assert.match(workflow, /candidate_scope:\n[\s\S]*- windows/u)
+  assert.match(workflow, /if: inputs\.candidate_scope == 'full' \|\| matrix\.platform == 'win32'/u)
+  assert.match(workflow, /pending-candidate-ledger:\n\s+needs:[^\n]+\n\s+if: inputs\.candidate_scope == 'full'/u)
   assert.doesNotMatch(workflow, /continue-on-error|\|\| true/u)
   assert.doesNotMatch(workflow, /macos-13/u)
   for (const run of workflowRunBodies(workflow)) {

--- a/desktop/ambient-orb/test/release-completion.test.mjs
+++ b/desktop/ambient-orb/test/release-completion.test.mjs
@@ -108,7 +108,7 @@ test('release candidate explicitly builds unsigned bytes and keeps trust-bound s
   assert.doesNotMatch(workflow, /require-release-signing|verify-signed-candidate|finalize:mac-notarization/u)
   assert.match(workflow, /inspect:release-package/u)
   assert.match(workflow, /collect:release-artifacts/u)
-  assert.match(workflow, /attest-build-provenance@v3/u)
+  assert.doesNotMatch(workflow, /attest-build-provenance|id-token:|attestations:/u)
   assert.match(workflow, /generate:pending-release-ledger/u)
   assert.match(workflow, /node desktop\/ambient-orb\/node_modules\/electron\/install\.js/u)
   assert.match(workflow, /npm run test:runtime\n\s+[^\n]*\n\s+[^\n]*\n\s+[^\n]*\n\s+if: runner\.os != 'Windows'/u)

--- a/desktop/ambient-orb/test/release-evidence.test.mjs
+++ b/desktop/ambient-orb/test/release-evidence.test.mjs
@@ -17,9 +17,7 @@ function artifact() {
 
 const ARTIFACT_TARGETS = [
   'darwin-arm64:app', 'darwin-arm64:dmg',
-  'darwin-x64:app', 'darwin-x64:dmg',
   'win32-x64:portable', 'win32-x64:nsis',
-  'linux-x64-gnu:appimage', 'linux-x64-gnu:deb',
 ]
 
 function artifactMatrix() {

--- a/desktop/ambient-orb/test/release-smoke-certificate.test.mjs
+++ b/desktop/ambient-orb/test/release-smoke-certificate.test.mjs
@@ -81,6 +81,7 @@ test('release smoke kit generates its TLS identity instead of copying ignored fi
     'utf8',
   )
   assert.match(source, /generateReleaseSmokeCertificate\(\{/u)
+  assert.match(source, /scripts\/run-unsigned-installed-smoke\.mjs/u)
   assert.match(source, /scripts\/windows-smoke-home\.mjs/u)
   assert.doesNotMatch(source, /resolve\(packageRoot, 'scripts\/release-smoke-(?:cert|key)\.pem'\)/u)
 })

--- a/desktop/ambient-orb/test/release-smoke-certificate.test.mjs
+++ b/desktop/ambient-orb/test/release-smoke-certificate.test.mjs
@@ -81,5 +81,6 @@ test('release smoke kit generates its TLS identity instead of copying ignored fi
     'utf8',
   )
   assert.match(source, /generateReleaseSmokeCertificate\(\{/u)
+  assert.match(source, /scripts\/windows-smoke-home\.mjs/u)
   assert.doesNotMatch(source, /resolve\(packageRoot, 'scripts\/release-smoke-(?:cert|key)\.pem'\)/u)
 })

--- a/docs/archs/00-overview.md
+++ b/docs/archs/00-overview.md
@@ -21,14 +21,15 @@ and speech ownership remain explicit.
 ## Reading the citations in code comments
 
 These volumes are the condensed public edition of a longer internal design series ("v3"; v1 and v2
-were internal predecessors and were never published). Module docstrings and comments cite the
-internal editions and their bookkeeping verbatim, because those citations record why each boundary
-exists:
+were internal predecessors and were never published). Module docstrings and comments still cite
+internal identifiers where they record why a boundary exists:
 
-- `R…` and `D…` are internal decision identifiers (accepted rules and deliberate decisions).
-- `Stage A/C/E`, `Phase A`, and `B1…B4` are internal development-stage and milestone names.
+- `R…` and `D…` are internal decision identifiers (accepted rules and deliberate decisions);
+  comments still cite identifiers such as `R105`.
+- `Stage A/C/E`, `Phase A`, and `B1…B4` were internal development-stage names and are not current
+  code labels.
 - Section numbers, quoted wording, and tables attributed to a volume refer to the internal edition,
   which is more detailed than the public file of the same name.
 
-The identifiers are preserved for traceability; the reasoning they point to survives in the
-docstrings themselves.
+Where those identifiers remain, they are preserved for traceability; the reasoning they point to
+survives in the docstrings themselves.

--- a/docs/archs/01-spine.md
+++ b/docs/archs/01-spine.md
@@ -1,14 +1,14 @@
 # 1. Runtime Spine
 
-The spine is a continuous event processor. It applies one event at a time, schedules asynchronous
-work into slots, and later consumes that work's progress or terminal event. The loop body never
-waits for an executor.
+The spine is a continuous event processor. It applies one event at a time, schedules model work into
+single-flight slots, and starts executor work as owned tasks identified by delegates. The loop body
+never waits for an executor.
 
 This yields stable ownership:
 
 - the event queue orders facts;
-- slots enforce single-flight constraints;
-- delegates identify outstanding work;
+- model slots (`fast`, `surrogate.watch`, `compress`) enforce single-flight constraints;
+- delegates identify outstanding executor work;
 - wake reasons preserve causality;
 - Floor prevents simultaneous user-facing responses.
 

--- a/docs/archs/02-memory.md
+++ b/docs/archs/02-memory.md
@@ -39,7 +39,7 @@ paths and credential spans do not become observations, diagnostics, snapshots, p
 items. Agent/model prose is not user evidence. ASR aliases are low-confidence candidates and cannot
 route; their candidate observations may remain private durable evidence but never become published
 card aliases. Only an explicit user confirmation can create a durable alias. The three-state merge
-distinguishes confirmation, supplement, and conflict; confirmed user evidence outranks lower-trust
+distinguishes confirm, supplement, and conflict; confirmed user evidence outranks lower-trust
 evidence, while conflict retains evidence without overwriting confirmed user wording. Suppression
 is a separate durable relation state that prevents later recall.
 
@@ -47,8 +47,9 @@ Publication is last-good: a locked, unavailable, or failed store leaves the prio
 readable with a degraded marker. Bounded compaction retains the 512 most recent observations per
 logical workspace subject to a 4096-observation global ceiling. Observation pruning does not cascade
 into relation cards or their current state. Relation evidence has its own hard 48-reference window,
-enforced transactionally on every relation write and repaired at startup: the incoming evidence,
-user evidence, and then the newest remaining evidence are retained. This stays below the
+enforced transactionally on every relation write and repaired at startup: newest incoming user
+evidence, then remaining incoming evidence, then existing user evidence, then the newest remaining
+existing evidence are retained. This stays below the
 recall projection's independent 64-reference defensive limit, so a long-lived relation cannot make
 recall permanently degraded. Relation-card payloads and the normalized evidence table are always
 updated together.
@@ -79,8 +80,9 @@ synchronously revokes the old current scope, while a bounded FIFO preserves A→
 A→B and B→C. If an admitted event must be dropped, inference fails closed rather than bridging
 the unknown gap. The same gap fence applies when an admitted event cannot be resolved or committed:
 the next successful workspace becomes a fresh anchor and only its successor may create a new edge.
-All durable graph timestamps use Unix seconds; the causal runtime's monotonic clock is not a
-persistence clock.
+Observation and card timestamps use Unix seconds; the causal runtime's monotonic clock is not a
+persistence clock. Operation-receipt `committed_at` and schema-migration `applied_at` values are
+Unix milliseconds.
 
 Transition provenance is authenticated independently of the caller's projected result. Inside the
 atomic store transaction, Nova re-runs the pure projector against current state and requires an
@@ -89,11 +91,11 @@ confidence, status, or evidence. A weak transition may supplement an existing hi
 relation, but it cannot replace that relation's confirmed wording, confidence, or state.
 
 Schema-v3 relation receipts contain the complete gated historical result and therefore replay
-exactly even after the current relation advances. Historical schema-v2 receipts did not persist that
-payload. Migration retains those receipt rows and may reconstruct a result only while the matching
-relation revision is still current; after the relation advances, the old operation returns the
-stable `STORE_OPERATION_CONFLICT` error. Nova never fabricates a historical card or discards the
-retained receipt to claim success.
+exactly even after the current relation advances. Older receipts that omitted that payload are
+retained as legacy rows. The store may reconstruct a result only while the matching relation
+revision is still current; after the relation advances, the old operation returns the stable
+`STORE_OPERATION_CONFLICT` error. Nova never fabricates a historical card or discards the retained
+receipt to claim success.
 
 Database upgrades are explicit and transactional. Nova validates the exact STRICT table columns,
 unique keys, composite foreign key, and receipt autoincrement invariant for the recorded version,

--- a/docs/archs/04-ports.md
+++ b/docs/archs/04-ports.md
@@ -1,12 +1,13 @@
 # 4. Ports
 
 Ports separate the runtime from domain integrations. An executor manifest declares a name, channel
-policy, and operations. Each operation specifies JSON parameters, trust, deadline, side-effect
-classification, and optional verification behavior.
+policy, and operations. Each operation specifies JSON parameters, `readonly`, `confirm`, a
+`deadline_budget`, optional `verifies` targets, `sensitive_params`, and whether the host waits for a
+`sync_result`. Trust is classified on the returned handoff, not on the op spec.
 
 Runtime binds a validated request into a delegate and passes a dispatch context to the adapter. The
-adapter returns a typed `Handoff`; it cannot mutate structured memory or emit speech. Progress uses
-the same delegate identity and is rejected when identity, operation, or lifecycle state does not
-match.
+adapter returns a typed `ExecutorHandoff`; it cannot mutate structured memory or emit speech.
+Progress uses the same delegate identity and is rejected when identity, operation, or lifecycle
+state does not match.
 
 This contract keeps provider and device code replaceable without weakening the spine.

--- a/docs/archs/05-executors.md
+++ b/docs/archs/05-executors.md
@@ -1,7 +1,10 @@
 # 5. Executors
 
 Nova Audio Agent ships deterministic simulators plus adapters for search, Codex (app-server),
-camera snapshots, Watch, and Guard. Assembly exposes only selected manifests.
+`cam` snapshots, Watch, and Guard. Assembly always includes search, cam, watch, and guard;
+configuration selects only `fast_sim`, `slow_sim`, or `codex`. Codex ships base (`run` / `status`),
+live (`steer`), and project (`project` / `confirm_project_action`) manifests. Realtime additionally
+exposes the non-executor `memory.recall` query tool.
 
 Adapter-local responsibilities include:
 

--- a/docs/archs/06-verification.md
+++ b/docs/archs/06-verification.md
@@ -4,7 +4,7 @@ The deterministic suite verifies event ordering, deadlines, identity fencing, me
 tool-schema authority, untrusted evidence handling, realtime correlation, playback acknowledgement,
 and desktop isolation.
 
-Adapter consistency tests apply the same contract checks to every production executor. Live smokes
+Each production executor has its own tests, including registry-adapter contract checks. Live smokes
 are separate because they require credentials, devices, or network services and must never be
 mistaken for CI evidence.
 

--- a/docs/archs/10-executor-onboarding.md
+++ b/docs/archs/10-executor-onboarding.md
@@ -3,10 +3,13 @@
 Add an executor in this order:
 
 1. Write the manifest and parameter schemas.
-2. Define trust, deadline, side-effect, and verification behavior for every operation.
+2. Define `readonly`, `confirm`, `deadline_budget`, `verifies`, `sensitive_params`, and
+   `sync_result` for every operation. Classify trust on the handoff, not on the op spec.
 3. Implement a transport-independent adapter with deterministic doubles.
-4. Add it to assembly's explicit registry and configuration literal.
-5. Add adapter-consistency, invalid-input, timeout, cancellation, and sanitization tests.
+4. Wire it in `buildAssembly`. Always-on adapters (search, cam, watch, guard) are constructed
+   there unconditionally. Configurable adapters also join the `fast_sim` / `slow_sim` / `codex`
+   configuration literal.
+5. Add invalid-input, timeout, cancellation, sanitization, and registry-adapter contract tests.
 6. Add a live smoke only after deterministic lifecycle coverage passes.
 7. Document credentials and least-privilege setup in Getting Started.
 

--- a/runtime/src/project-native-resource.ts
+++ b/runtime/src/project-native-resource.ts
@@ -29,10 +29,14 @@ const PROJECT_ADDON_ID = 'project_native_addon'
 const MAX_MANIFEST_BYTES = 1024 * 1024
 const MAX_ADDON_BYTES = 16 * 1024 * 1024
 const MODULE_EXPORTS = Object.freeze([
-  'acquire', 'createFileAt', 'lookupAt', 'lookupWorkspaceAt', 'matchesAt', 'matchesWorkspaceAt',
-  'mkdirAt', 'mkdirPrivateAt', 'openDirectory',
+  'acquire', 'createFileAt', 'lookupAt', 'matchesAt', 'mkdirAt', 'mkdirPrivateAt', 'openDirectory',
   'probe', 'protectAt', 'removeTreeAt', 'renameAt', 'renameNoReplaceAt', 'syncDirectory', 'unlinkAt',
 ])
+const WINDOWS_MODULE_EXPORTS = Object.freeze([
+  ...MODULE_EXPORTS,
+  'lookupWorkspaceAt',
+  'matchesWorkspaceAt',
+].sort())
 
 export interface ProjectDirectoryHandle {
   readonly fd: number
@@ -191,7 +195,10 @@ function loadSupportedProjectNativeHostFromResources(
     const materialized = materializeAddonSnapshot(before)
     let addon: ProjectAddon | null
     try {
-      addon = requireAddon((options.moduleLoader ?? defaultModuleLoader)(materialized.path))
+      addon = requireAddon(
+        (options.moduleLoader ?? defaultModuleLoader)(materialized.path),
+        options.platform,
+      )
       if (addon === null || !sameSnapshot(materialized.snapshot, snapshotRegularFile(
         materialized.path,
         MAX_ADDON_BYTES,
@@ -210,11 +217,15 @@ function loadSupportedProjectNativeHostFromResources(
     const rootFiles: ProjectRootFileAuthority = Object.freeze({
       probe: (descriptor: number) => addon.probe(descriptor),
       matchesAt: (root: number, name: string, child: number) => addon.matchesAt(root, name, child),
-      matchesWorkspaceAt: (root: number, name: string, child: number) => (
-        addon.matchesWorkspaceAt(root, name, child)
-      ),
       lookupAt: (root: number, name: string) => addon.lookupAt(root, name),
-      lookupWorkspaceAt: (root: number, name: string) => addon.lookupWorkspaceAt(root, name),
+      ...(addon.matchesWorkspaceAt === undefined ? {} : {
+        matchesWorkspaceAt: (root: number, name: string, child: number) => (
+          addon.matchesWorkspaceAt!(root, name, child)
+        ),
+      }),
+      ...(addon.lookupWorkspaceAt === undefined ? {} : {
+        lookupWorkspaceAt: (root: number, name: string) => addon.lookupWorkspaceAt!(root, name),
+      }),
       createFileAt: (root: number, name: string, exclusive: boolean) => (
         addon.createFileAt(root, name, exclusive)
       ),
@@ -424,8 +435,8 @@ function validBinary(bytes: Buffer, platform: string, arch: string): boolean {
 interface ProjectAddon extends NativeFileLockAuthority, ProjectRootFileAuthority {
   openDirectory(path: string): unknown
   protectAt(root: number, name: string, child: number): ProjectRootFileResult
-  matchesWorkspaceAt(root: number, name: string, child: number): ProjectRootFileResult
-  lookupWorkspaceAt(root: number, name: string): ProjectRootFileLookupResult
+  matchesWorkspaceAt?(root: number, name: string, child: number): ProjectRootFileResult
+  lookupWorkspaceAt?(root: number, name: string): ProjectRootFileLookupResult
   mkdirPrivateAt(root: number, name: string): ProjectRootFileCreateResult
   renameNoReplaceAt(
     root: number,
@@ -472,12 +483,13 @@ function isStatus(value: unknown, status: string): boolean {
   return Object.hasOwn(descriptor, 'value') && descriptor.value === status
 }
 
-function requireAddon(value: unknown): ProjectAddon | null {
+function requireAddon(value: unknown, platform: string): ProjectAddon | null {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return null
   const descriptors = Object.getOwnPropertyDescriptors(value)
-  if (Object.keys(descriptors).sort().join('\0') !== MODULE_EXPORTS.join('\0')) return null
+  const expected = platform === 'win32' ? WINDOWS_MODULE_EXPORTS : MODULE_EXPORTS
+  if (Object.keys(descriptors).sort().join('\0') !== expected.join('\0')) return null
   const methods: Partial<Record<(typeof MODULE_EXPORTS)[number], (...args: never[]) => unknown>> = {}
-  for (const name of MODULE_EXPORTS) {
+  for (const name of expected) {
     const descriptor = descriptors[name]
     if (
       descriptor === undefined

--- a/runtime/test/project-native-resource.test.ts
+++ b/runtime/test/project-native-resource.test.ts
@@ -28,9 +28,7 @@ function fakeAddon(): Record<string, (...args: readonly unknown[]) => unknown> {
     probe: () => ({status: 'ok'}),
     protectAt: () => ({status: 'ok'}),
     matchesAt: () => ({status: 'ok'}),
-    matchesWorkspaceAt: () => ({status: 'ok'}),
     lookupAt: () => ({status: 'missing'}),
-    lookupWorkspaceAt: () => ({status: 'missing'}),
     createFileAt: () => ({status: 'exists'}),
     mkdirAt: () => ({status: 'exists'}),
     mkdirPrivateAt: () => ({status: 'ok', identity: {device: 1n, inode: 2n}}),
@@ -84,6 +82,8 @@ test('project native host loads only one fixed manifest-bound addon for the exac
     assert.equal(loads, 1)
     assert.deepEqual(loaded?.nativeLocks.acquire(7), {status: 'busy'})
     assert.deepEqual(loaded?.rootFiles.probe(8), {status: 'ok'})
+    assert.equal(Object.hasOwn(loaded?.rootFiles ?? {}, 'matchesWorkspaceAt'), false)
+    assert.equal(Object.hasOwn(loaded?.rootFiles ?? {}, 'lookupWorkspaceAt'), false)
     assert.deepEqual(loaded?.rootFiles.removeTreeAt(8, 'tombstone', {device: 1n, inode: 2n}), {
       status: 'ok',
     })


### PR DESCRIPTION
## Summary
- require Windows ACL workspace exports only on Windows
- keep Darwin/Linux native addon export validation strict
- expose optional workspace ACL methods only when the platform addon implements them

## Verification
- npm run typecheck --workspace @nova-audio-agent/runtime
- targeted project-native-resource tests (4/4)
- npm run test:runtime (1858 pass, 1 skip)
- npm run test:desktop (759 pass, 3 skip)
- npm run check
- macOS arm64 candidate package installed smoke passed
- hdiutil verify confirms the generated DMG is VALID

This fixes Candidate run 33476550503 failing at host_project_native without changing the desktop or runtime core execution path.